### PR TITLE
fix(cursor_setup): ensure consistent locale for MB conversion

### DIFF
--- a/cursor_setup.sh
+++ b/cursor_setup.sh
@@ -130,7 +130,9 @@ extract_version() {
   echo "Error: No version found in filename" >&2; return 1
 }
 
-convert_to_mb() { printf "%.2f MB" "$(bc <<< "scale=2; $1 / 1048576")"; }
+convert_to_mb() { 
+    LC_NUMERIC=C printf "%.2f MB" "$(bc <<< "scale=2; $1 / 1048576")"
+}
 
 spinner() {
   local title="$1" command="$2" chars="|/-\\" i=0


### PR DESCRIPTION
- Added LC_NUMERIC=C to convert_to_mb() function
- Prevents potential locale-related formatting issues
- Ensures consistent decimal point representation during file size conversion

Fix from error:
```
cursor_setup.sh: line 133: printf: 147.18: invalid number
 »  Local version found:                                              
      - name: cursor-0.45.14x86_64.AppImage                           
      - version: 0.45.14                                              
      - size: 147,00 MB 
```